### PR TITLE
preventing AttributeError caused by tensor.shape[axis].value in tf 2.0

### DIFF
--- a/tensorflow_graphics/util/shape.py
+++ b/tensorflow_graphics/util/shape.py
@@ -367,7 +367,7 @@ def compare_dimensions(tensors, axes, tensor_names=None):
     tensor_names = _give_default_names(tensors, 'tensor')
   if not tf.executing_eagerly():
     dimensions = [
-        int(tensor.shape[axis]) if tensor.shape[axis].value is not None else 1
+        int(tensor.shape[axis]) if _get_dim(tensor,axis) is not None else 1
         for tensor, axis in zip(tensors, axes)
     ]
   else:


### PR DESCRIPTION
in tf 2.0 `tensor.shape[axis].value`  raises "AttributeError: 'int' object has no attribute 'value'" if not executed eagerly. 
Demonstration:
https://colab.research.google.com/drive/1TTtNwEF4TjWQoXdvjpWky-dnXN1zFu13#scrollTo=V5vOv0Qnl1Tk
It's replaced in `_check_tensors` function by `_get_dim(tensor,axis)`  as proposed by @julienvalentin in https://github.com/tensorflow/graphics/issues/15#issuecomment-533034402_