### PR TITLE
sparse_matmul implementation, softmax stability, layer configs

### DIFF
--- a/benchmarks/graph_convolution_benchmark.py
+++ b/benchmarks/graph_convolution_benchmark.py
@@ -1,0 +1,134 @@
+from absl import logging
+from absl import app, flags
+import numpy as np
+import tensorflow as tf
+from tensorflow_graphics.nn.layer.graph_convolution import \
+  FeatureSteeredConvolutionKerasLayer
+from tensorflow_graphics.geometry.convolution.graph_convolution import \
+  SparseImplementation
+
+logging.info('Finished imports')
+
+Lambda = tf.keras.layers.Lambda
+Input = tf.keras.Input
+
+flags.DEFINE_boolean('jit', default=False, help='use XLA jit compilation')
+flags.DEFINE_boolean('sparse', default=False, help='use sparse implementation')
+flags.DEFINE_boolean('sort', default=False, help='use sorted indices')
+flags.DEFINE_boolean(
+    'backward', default=False, help='benchmark forward and backward pass')
+flags.DEFINE_integer(
+    'burn_iters', default=10, help='number of burn in iterations')
+flags.DEFINE_integer('nv', default=100000, help='number of vertices')
+flags.DEFINE_integer('ne',
+           default=-1,
+           help='number of edges, -1 will result in using 10*nv')
+flags.DEFINE_integer('min_iters',
+           default=20,
+           help='minimum number of iterations to benchmark')
+flags.DEFINE_integer(
+    'num_weight_matrices', default=8, help='number of weight matrices')
+flags.DEFINE_integer(
+    'num_output_channels', default=32, help='number of output channels')
+flags.DEFINE_integer('num_layers', default=10, help='number of layers')
+
+
+def summarize(result, print_fn=print):
+  """
+  Args:
+    result: output of a tf.test.Benchmark.run_op_benchmark call.
+    print_fn: print-like function.
+  """
+  print_fn('Wall time (ms): {}'.format(result['wall_time'] * 1000))
+  gpu_mem = result['extras'].get('allocator_maximum_num_bytes_GPU_0_bfc', 0)
+  print_fn('Memory (Mb):  {}'.format(gpu_mem / 1024**2))
+
+
+def get_data(num_vertices, num_edges, sort=True):
+  if num_edges == -1:
+    num_edges = 10 * num_vertices
+  vertices = np.random.uniform(size=(num_vertices, 3)).astype(np.float32)
+  # replace=False below gives memory issues
+  indices = np.random.choice(num_vertices**2, num_edges, replace=True)
+  if sort:
+    indices.sort()
+  i, j = np.unravel_index(indices, (num_vertices, num_vertices))  # pylint: disable=unbalanced-tuple-unpacking
+
+  counts = np.zeros((num_vertices,), dtype=np.int64)
+  for ii in i:
+    counts[ii] += 1
+  weights = (1. / counts)[i].astype(np.float32)
+  indices = np.stack((i, j), axis=-1)
+
+  return vertices, indices, weights
+
+
+def main(_):
+  FLAGS = flags.FLAGS
+  tf.config.optimizer.set_jit(FLAGS.jit)
+  tf.keras.backend.clear_session()
+  vertices, indices, weights = get_data(FLAGS.nv, FLAGS.ne, sort=FLAGS.sort)
+  nv = vertices.shape[0]
+
+  with tf.Graph().as_default():
+    vertices = tf.constant(vertices, dtype=tf.float32)
+    indices = tf.constant(indices, dtype=tf.int64)
+    weights = tf.constant(weights, dtype=tf.float32)
+    # batch size of 1
+    vertices, indices, weights = (
+        tf.expand_dims(t, axis=0) for t in (vertices, indices, weights))
+
+    data = Input(tensor=vertices)
+    indices = Input(tensor=indices)
+    weights = Input(tensor=weights)
+    inputs = (data, indices, weights)
+    data, indices, weights = tuple(
+      Lambda(tf.squeeze, arguments=dict(axis=0), name='squeeze{}'.format(i))(t)
+      for i, t in enumerate(inputs))
+    nv = Lambda(lambda x: tf.shape(x, out_type=tf.int64)[0])(data)
+
+    neighbors = Lambda(
+        lambda args: tf.SparseTensor(args[0], args[1], (args[2], args[2])))(
+            [indices, weights, nv])
+
+    for _ in range(FLAGS.num_layers):
+      layer = FeatureSteeredConvolutionKerasLayer(
+          sparse_impl=(
+              SparseImplementation.SPARSE_MATMUL if FLAGS.sparse else
+              SparseImplementation.GATHER_SUM),
+          num_weight_matrices=FLAGS.num_weight_matrices,
+          num_output_channels=FLAGS.num_output_channels)
+      data = layer([data, neighbors])
+      data = tf.nn.relu(data)
+
+    pred = data
+    output = Lambda(tf.expand_dims, arguments=dict(axis=0))(pred)
+    model = tf.keras.Model(inputs=inputs, outputs=output)
+
+    if FLAGS.backward:
+      loss = tf.reduce_sum(pred)
+      optimizer = tf.keras.optimizers.SGD()
+
+      model_weights = model.trainable_weights
+
+      grads = optimizer.get_gradients(loss, model_weights)
+      grads_and_vars = tuple(zip(grads, model_weights))
+      train_op = optimizer.apply_gradients(grads_and_vars)
+    else:
+      train_op = pred
+
+    bm = tf.test.Benchmark()
+    with tf.compat.v1.Session() as sess:
+      logging.info('Initializing variables...')
+
+      sess.run(tf.compat.v1.global_variables_initializer())
+
+      logging.info('Starting benchmarking...')
+      result = bm.run_op_benchmark(
+          sess, train_op, burn_iters=FLAGS.burn_iters,
+          min_iters=FLAGS.min_iters)
+    summarize(result)
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/tensorflow_graphics/geometry/convolution/tests/graph_convolution_test.py
+++ b/tensorflow_graphics/geometry/convolution/tests/graph_convolution_test.py
@@ -333,13 +333,23 @@ class GraphConvolutionTestFeatureSteeredConvolutionTests(test_case.TestCase):
 
   @parameterized.parameters(
       (((1.0,), (2.0,), (3.0,)), np.ones(shape=(3, 3)) / 3.0, ((0.5,),),
-       ((1.3,),), (-0.7,), (((0.8,),),), (3.0,), ((4.6,), (4.6,), (4.6,))),
+       ((1.3,),), (-0.7,), (((0.8,),),), (3.0,), ((4.6,), (4.6,), (4.6,)),
+       'gather_sum'),
       (((1.0,), (2.0,), (3.0,)), np.ones(shape=(3, 3)) / 3.0, ((0.5, 0.2),),
        ((0.3, 0.4),), (-0.7, 0.15), (((0.8,),), ((1.1,),)), (3.0,),
-       ((5.011706928844621,), (4.971030281984818,), (4.927388658982911,))),
+       ((5.011706928844621,), (4.971030281984818,), (4.927388658982911,)),
+       'gather_sum'),
+      (((1.0,), (2.0,), (3.0,)), np.ones(shape=(3, 3)) / 3.0, ((0.5,),),
+       ((1.3,),), (-0.7,), (((0.8,),),), (3.0,), ((4.6,), (4.6,), (4.6,)),
+       'sparse_matmul'),
+      (((1.0,), (2.0,), (3.0,)), np.ones(shape=(3, 3)) / 3.0, ((0.5, 0.2),),
+       ((0.3, 0.4),), (-0.7, 0.15), (((0.8,),), ((1.1,),)), (3.0,),
+       ((5.011706928844621,), (4.971030281984818,), (4.927388658982911,)),
+       'sparse_matmul'),
   )
   def test_feature_steered_convolution_padding_preset(self, data, neighbors, u,
-                                                      v, c, w, b, expected):
+                                                      v, c, w, b, expected,
+                                                      sparse_impl):
     """Test expected result for preset data and filter values."""
     array = (np.array(i) for i in (data, neighbors, expected))
     data, neighbors, expected = array
@@ -354,7 +364,8 @@ class GraphConvolutionTestFeatureSteeredConvolutionTests(test_case.TestCase):
         var_v=v,
         var_c=c,
         var_w=w,
-        var_b=b)
+        var_b=b,
+        sparse_impl=sparse_impl)
     self.assertAllClose(y, expected)
 
   @parameterized.parameters(


### PR DESCRIPTION
This PR is mostly focused on adding a `'sparse_matmul'` implementation of `feature_steered_convolution` which is faster than the base version (`'gather_sum'`) in certain circumstances.

Differences can be seen in the benchmarking script.

```bash
cd benchmarks
python graph_convolution_benchmark.py --backward --sort
# Wall time (ms): 1173.0027198791504
# Memory (Mb):  5350.4373207092285
python graph_convolution_benchmark.py --backward --sort --sparse
# Wall time (ms): 885.279655456543
# Memory (Mb):  4426.739643096924
```
Benefits are similar though reduced when using `--jit` option.

Note these benefits are not across-the-board, hence the choice of implementation is left to the user. For example, smaller networks are faster using `gather_sum`. Verify with `--num_layers=2` or similar.

Other minor changes:

- numerically stable softmax implementation (this is faster than `tf.nn.softmax` when using JIT)
- documentation: `feature_steered_convolution` can take non-square neighborhood tensors. Updated documentation to reflect this.
- layers: added `get_config` implementations and `tf.keras.*.get` calls in constructors, allowing `Layer.from_config` to work as intended.