### PR TITLE
Adding a redner submodule

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -19,7 +19,7 @@ exclude = .git,
           .tox,
           .pytest_cache,
           __pycache__,
-          projects/*
+          tensorflow_graphics/projects/*
 ignore = C901,
          E101,
          E111,

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "tensorflow_graphics/projects/redner"]
+	path = tensorflow_graphics/projects/redner
+	url = https://github.com/BachiLi/redner
+	branch = tf_graphics


### PR DESCRIPTION
This PR adds a submodule of [redner](https://github.com/BachiLi/redner) in the projects folder, pointing to a TF graphics branch in that repository. The main change of the redner TF graphics branch compared to the master branch currently lies in the README: the installation instruction is changed and there is some description of TF graphics in the README.

In the future we want to:
1) Add redner into TF graphics namespace (e.g., `import tensorflow_graphics.pyredner`).
2) Add redner into TF graphics' pip package
3) Adding rendering functions in TF graphics that use redner.
4) Potentially unifying part of TF graphics' rasterizer and redner