### PR TITLE
A couple of small fixes

### DIFF
--- a/tensorflow_graphics/g3doc/_index.ipynb
+++ b/tensorflow_graphics/g3doc/_index.ipynb
@@ -62,7 +62,7 @@
         "id": "q4fzyll4LvQc"
       },
       "source": [
-        "If Tensorflow Graphics and Trimesh are not installed on your system the following cell can install theses package for you."
+        "If Tensorflow Graphics and Trimesh are not installed on your system the following cell can install these packages for you."
       ]
     },
     {
@@ -110,7 +110,7 @@
         "import tensorflow_graphics.geometry.transformation as tfg_transformation\n",
         "from tensorflow_graphics.notebooks import threejs_visualization\n",
         "\n",
-        "tf.enable_eager_execution()"
+        "tf.compat.v1.enable_v2_behavior()"
       ]
     },
     {
@@ -163,8 +163,8 @@
       "version": "0.3.2"
     },
     "kernelspec": {
-      "display_name": "Python 2",
-      "name": "python2"
+      "display_name": "Python 3",
+      "name": "python3"
     }
   },
   "nbformat": 4,

--- a/tensorflow_graphics/g3doc/install.md
+++ b/tensorflow_graphics/g3doc/install.md
@@ -3,8 +3,7 @@
 ## Stable builds
 
 TensorFlow Graphics depends on [TensorFlow](https://www.tensorflow.org/install)
-1.13.1 or above. Nightly builds of TensorFlow that tf-nightly and
-tf-nightly-2.0-preview are also supported.
+1.13.1 or above. Nightly builds of TensorFlow (tf-nightly) are also supported.
 
 To install the latest CPU version from
 [PyPI](https://pypi.org/project/tensorflow-graphics/), run the following:

--- a/tensorflow_graphics/notebooks/6dof_alignment.ipynb
+++ b/tensorflow_graphics/notebooks/6dof_alignment.ipynb
@@ -681,8 +681,8 @@
       "version": "0.3.2"
     },
     "kernelspec": {
-      "display_name": "Python 2",
-      "name": "python2"
+      "display_name": "Python 3",
+      "name": "python3"
     }
   },
   "nbformat": 4,

--- a/tensorflow_graphics/notebooks/interpolation.ipynb
+++ b/tensorflow_graphics/notebooks/interpolation.ipynb
@@ -61,7 +61,7 @@
       "source": [
         "Given a limited number of pre-defined points and associated values, interpolation allows to predict new data points within the range of the pre-defined points.\n",
         "\n",
-        "In the example below, the left plot shows samples represented as blue dots. Assuming that these samples come from a smooth function, one has many options avaiable to find plausible values *between* these dots. A first option is to build a piece-wise linear function which links any pair of neighbouring points with a line, as can be observed in the cental plot. Another widely used option is to fit a polynomial to these samples. The right plot illustrates a cubic polynomial fitted to the samples.\n",
+        "In the example below, the left plot shows samples represented as blue dots. Assuming that these samples come from a smooth function, one has many options available to find plausible values *between* these dots. A first option is to build a piece-wise linear function which links any pair of neighbouring points with a line, as can be observed in the central plot. Another widely used option is to fit a polynomial to these samples. The right plot illustrates a cubic polynomial fitted to the samples.\n",
         "\n",
         "![](https://storage.googleapis.com/tensorflow-graphics/notebooks/interpolation/interpolations.png)\n",
         "\n",
@@ -132,9 +132,9 @@
       },
       "source": [
         "## Slerp interpolation\n",
-        "Lerp is a widely used interpolation technique allowing to linearly interpolate between points. The piece-wise linear interpolation described at the beginning of this Colab effectively consists of pieces of linear interpolants. But what about if our data lives on a circle or at the surface of a sphere? In that case, Lerp would not provide a good way to interpolate, but fortunately, Slerp would! Slerp stands for *spherical* linear interpolation and has been introduced in the context of interplating quaternions, which is a rotation formalism. We refer the interested reader to the [wikipedia page for Slerp](https://en.wikipedia.org/wiki/Slerp) for further details.\n",
+        "Lerp is a widely used interpolation technique allowing to linearly interpolate between points. The piece-wise linear interpolation described at the beginning of this Colab effectively consists of pieces of linear interpolants. But what about if our data lives on a circle or at the surface of a sphere? In that case, Lerp would not provide a good way to interpolate, but fortunately, Slerp would! Slerp stands for *spherical* linear interpolation and has been introduced in the context of interpolating quaternions, which is a rotation formalism. We refer the interested reader to the [wikipedia page for Slerp](https://en.wikipedia.org/wiki/Slerp) for further details.\n",
         "\n",
-        "The following demo allows to define two vectors, each starting from the center of a circle and ending on the circle. These define the vectors we want to interpolate between, and the slider 'percent' controls the extend to which each vector influence the interpolated vector. Note that the resulting vector also ends on the circle.\n"
+        "The following demo allows to define two vectors, each starting from the center of a circle and ending on the circle. These define the vectors we want to interpolate between, and the slider 'percent' controls the extent to which each vector influences the interpolated vector. Note that the resulting vector also ends on the circle.\n"
       ]
     },
     {
@@ -252,8 +252,8 @@
       "version": "0.3.2"
     },
     "kernelspec": {
-      "display_name": "Python 2",
-      "name": "python2"
+      "display_name": "Python 3",
+      "name": "python3"
     }
   },
   "nbformat": 4,

--- a/tensorflow_graphics/notebooks/intrinsics_optimization.ipynb
+++ b/tensorflow_graphics/notebooks/intrinsics_optimization.ipynb
@@ -63,11 +63,11 @@
         "\n",
         "![](https://storage.googleapis.com/tensorflow-graphics/notebooks/intrinsics/camera_model.jpg)\n",
         "\n",
-        " This model is composed of two parameters that are often refered to as intrinsic parameters:\n",
+        " This model is composed of two parameters that are often referred to as intrinsic parameters:\n",
         "- the principal point, which is the projection of the optical center on the image. Ideally, the principal point is close to the center of the image.\n",
         "- the focal length, which is the distance between the optical center and the image plane. This parameters allows to control the level of zoom.\n",
         "\n",
-        "This notebook illustrates how to use [Tensorflow Graphics](https://github.com/tensorflow/graphics) to estimate the intrinsic parameters of a projective camera. Recovering these parameters is particularly imporant to perform several tasks, including 3D reconstruction.\n",
+        "This notebook illustrates how to use [Tensorflow Graphics](https://github.com/tensorflow/graphics) to estimate the intrinsic parameters of a projective camera. Recovering these parameters is particularly important to perform several tasks, including 3D reconstruction.\n",
         "\n",
         "In this Colab, the goal is to recover the intrinsic parameters of a camera given an observation and correspondences between the observation and the render of the current solution.  Things are kept simple by only inserting a rectangle in the 3D scene, and using it as the source of correspondences during the optimization. The minimization is performed using the Levenberg-Marquardt algorithm."
       ]
@@ -222,7 +222,7 @@
         "ideal_principal_point = np.array(\n",
         "    (image_width, image_height), dtype=np.float64) / 2.0\n",
         "\n",
-        "# Let's see what our scene looks like using the intrinsic paramters defined above.\n",
+        "# Let's see what our scene looks like using the intrinsic parameters defined above.\n",
         "render = render_rectangle(rectangle_vertices, focal_lengths, ideal_principal_point,\n",
         "                          image_dimensions)\n",
         "_ = plt.imshow(render)"
@@ -355,7 +355,7 @@
         "id": "QTdXuY6BapnT"
       },
       "source": [
-        "As described earlier, one can compare how the 3D object would look using the current estimate of the intrinsic parameters, can compare that to the actual observation. The following function captures a distance beween these two images which we will seek to minimize."
+        "As described earlier, one can compare how the 3D object would look using the current estimate of the intrinsic parameters, can compare that to the actual observation. The following function captures a distance between these two images which we will seek to minimize."
       ]
     },
     {
@@ -403,7 +403,7 @@
         "real_focal_lengths, real_principal_point, estimate_focal_lengths, estimate_principal_point = build_parameters(\n",
         ")\n",
         "\n",
-        "# Contructs the observed image.\n",
+        "# Constructs the observed image.\n",
         "observation = render_rectangle(rectangle_vertices, real_focal_lengths,\n",
         "                               real_principal_point, image_dimensions)\n",
         "\n",
@@ -444,8 +444,8 @@
       "version": "0.3.2"
     },
     "kernelspec": {
-      "display_name": "Python 2",
-      "name": "python2"
+      "display_name": "Python 3",
+      "name": "python3"
     }
   },
   "nbformat": 4,

--- a/tensorflow_graphics/notebooks/mesh_segmentation_demo.ipynb
+++ b/tensorflow_graphics/notebooks/mesh_segmentation_demo.ipynb
@@ -1,4 +1,19 @@
 {
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "mesh_segmentation_demo.ipynb",
+      "provenance": [],
+      "private_outputs": true,
+      "collapsed_sections": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    }
+  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -12,14 +27,12 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
         "cellView": "form",
-        "colab": {},
         "colab_type": "code",
-        "id": "Okg-R95R1CaX"
+        "id": "Okg-R95R1CaX",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
@@ -32,6 +45,26 @@
         "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License."
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "x09idYC2vsZQ",
+        "colab_type": "text"
+      },
+      "source": [
+        "# Mesh Segmentation using Feature Steered Graph Convolutions\n",
+        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/graphics/blob/master/tensorflow_graphics/notebooks/mesh_segmentation_demo.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/graphics/blob/master/tensorflow_graphics/notebooks/mesh_segmentation_demo.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "  </td>\n",
+        "</table>"
       ]
     },
     {
@@ -75,7 +108,7 @@
         "the recent years. In this demo we use the method described in\n",
         "[Feature Steered Graph Convolutions](https://arxiv.org/abs/1706.05206). Similar\n",
         "to it's image counterpart, this basic building block can be used do solve a\n",
-        "plethora of problems. This Colab focusses on segmenting deformable meshes of\n",
+        "plethora of problems. This Colab focuses on segmenting deformable meshes of\n",
         "human bodies into parts (e.g. head, right foot, etc.)."
       ]
     },
@@ -86,7 +119,7 @@
         "id": "PNQ29y8Q4_cH"
       },
       "source": [
-        "## Setup \u0026 Imports\n",
+        "## Setup & Imports\n",
         "\n",
         "To run this Colab optimally, please update the runtime type to use a GPU\n",
         "hardware accelerator. - click on the 'Runtime' menu, then 'Change runtime type':\n",
@@ -103,16 +136,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "26AvKq8MJRGl"
+        "id": "26AvKq8MJRGl",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "!pip install tensorflow_graphics"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -126,13 +159,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "KlBviBxue7n0"
+        "id": "KlBviBxue7n0",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "from __future__ import absolute_import\n",
         "from __future__ import division\n",
@@ -145,7 +176,9 @@
         "from tensorflow_graphics.nn.layer import graph_convolution as graph_conv\n",
         "from tensorflow_graphics.notebooks import mesh_segmentation_dataio as dataio\n",
         "from tensorflow_graphics.notebooks import mesh_viewer"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -171,13 +204,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "_ZkB3iIcvvzJ"
+        "id": "_ZkB3iIcvvzJ",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "path_to_model_zip = tf.keras.utils.get_file(\n",
         "    'model.zip',\n",
@@ -195,7 +226,9 @@
         "        os.path.dirname(path_to_data_zip),\n",
         "        'data/Dancer_test_sequence.tfrecords')\n",
         "]"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -238,19 +271,17 @@
         "For details on the dataset pipeline implementation, take a look at\n",
         "mesh_segmentation_dataio.py.\n",
         "\n",
-        "Lets try to load a batch from the test TFRecordDataset, and visualize the first\n",
+        "Let's try to load a batch from the test TFRecordDataset, and visualize the first\n",
         "mesh with each vertex colored by the part label."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "LZM02o0pEny6"
+        "id": "LZM02o0pEny6",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "test_io_params = {\n",
         "    'is_training': False,\n",
@@ -273,7 +304,9 @@
         "    'vertex_colors': mesh_viewer.SEGMENTATION_COLORMAP[test_labels[0, ...]],\n",
         "}\n",
         "input_viewer = mesh_viewer.Viewer(input_mesh_data)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -286,7 +319,7 @@
         "\n",
         "Given a mesh with V vertices and D-dimensional per-vertex input features (e.g.\n",
         "vertex position, normal), we would like to create a network capable of\n",
-        "classifying each vertex to a part label. Lets first create a mesh encoder that\n",
+        "classifying each vertex to a part label. Let's first create a mesh encoder that\n",
         "encodes each vertex in the mesh into C-dimensional logits, where C is the number\n",
         "of parts. First we use 1x1 convolutions to change input feature dimensions,\n",
         "followed by a sequence of feature steered graph convolutions and ReLU\n",
@@ -300,13 +333,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "fQVeuGazM0LK"
+        "id": "fQVeuGazM0LK",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "MODEL_PARAMS = {\n",
         "    'num_filters': 8,\n",
@@ -341,7 +372,7 @@
         "  \"\"\"\n",
         "  batch_vertices = batch_mesh_data['vertices']\n",
         "\n",
-        "  # Linear: N x D --\u003e N x 16.\n",
+        "  # Linear: N x D --> N x 16.\n",
         "  vertex_features = tf.keras.layers.Conv1D(16, 1, name='lin16')(batch_vertices)\n",
         "\n",
         "  # graph convolution layers\n",
@@ -355,19 +386,21 @@
         "          num_output_channels=dim)\n",
         "    vertex_features = tf.nn.relu(vertex_features)\n",
         "\n",
-        "  # Linear: N x 128 --\u003e N x 256.\n",
+        "  # Linear: N x 128 --> N x 256.\n",
         "  vertex_features = tf.keras.layers.Conv1D(\n",
         "      256, 1, name='lin256')(\n",
         "          vertex_features)\n",
         "  vertex_features = tf.nn.relu(vertex_features)\n",
         "\n",
-        "  # Linear: N x 256 --\u003e N x output_dim.\n",
+        "  # Linear: N x 256 --> N x output_dim.\n",
         "  vertex_features = tf.keras.layers.Conv1D(\n",
         "      output_dim, 1, name='lin_output')(\n",
         "          vertex_features)\n",
         "\n",
         "  return vertex_features"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -384,13 +417,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "WE-cuv0i78ak"
+        "id": "WE-cuv0i78ak",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "def get_learning_rate(params):\n",
         "  \"\"\"Returns a decaying learning rate.\"\"\"\n",
@@ -447,7 +478,9 @@
         "  }\n",
         "  return tf.estimator.EstimatorSpec(\n",
         "      mode=mode, loss=loss, eval_metric_ops=eval_ops)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -456,20 +489,18 @@
         "id": "94FICCro_dLV"
       },
       "source": [
-        "## Test model \u0026 visualize results\n",
+        "## Test model & visualize results\n",
         "\n",
         "Now that we have defined the model, let's load the weights from the trained model downloaded above and use tf.Estimator.predict to predict the part labels for meshes in the test dataset."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "Olj5zIkg72FK"
+        "id": "Olj5zIkg72FK",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "test_io_params = {\n",
         "    'is_training': False,\n",
@@ -489,7 +520,9 @@
         "                                   model_dir=local_model_dir,\n",
         "                                   params=MODEL_PARAMS)\n",
         "test_predictions = estimator.predict(input_fn=predict_fn)\n"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -503,13 +536,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "xuoVe70D5PAF"
+        "id": "xuoVe70D5PAF",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "prediction = next(test_predictions)\n",
         "input_mesh_data = {\n",
@@ -524,7 +555,9 @@
         "\n",
         "input_viewer = mesh_viewer.Viewer(input_mesh_data)\n",
         "prediction_viewer = mesh_viewer.Viewer(predicted_mesh_data)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -533,7 +566,7 @@
         "id": "QE8Meyi5GKWA"
       },
       "source": [
-        "## Train the model from scratch.\n",
+        "## Train the model from scratch\n",
         "\n",
         "Now let's train the mesh segmentation model from scratch. First we will download the train dataset files, and use tf.Estimator.train_and_evaluate to train a model.\n",
         "\n",
@@ -542,13 +575,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "S6vxJ8t5HRcS"
+        "id": "S6vxJ8t5HRcS",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "path_to_train_data_zip = tf.keras.utils.get_file(\n",
         "    'train_data.zip',\n",
@@ -559,17 +590,17 @@
         "    os.path.join(os.path.dirname(path_to_train_data_zip), '*train*.tfrecords'))\n",
         "\n",
         "retrain_model_dir = os.path.join(local_model_dir, 'retrain')"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "inNSvIN-HcBg"
+        "id": "inNSvIN-HcBg",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "train_io_params = {\n",
         "    'batch_size': 8,\n",
@@ -627,29 +658,12 @@
         "    start_delay_secs=2 * checkpoint_delay,\n",
         "    throttle_secs=checkpoint_delay)\n",
         "\n",
-        "print('Start training \u0026 eval.')\n",
+        "print('Start training & eval.')\n",
         "tf.estimator.train_and_evaluate(classifier, train_spec, eval_spec)\n",
         "print('Train and eval done.')"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     }
-  ],
-  "metadata": {
-    "colab": {
-      "collapsed_sections": [],
-      "last_runtime": {
-        "build_target": "//learning/brain/python/client:colab_notebook",
-        "kind": "private"
-      },
-      "name": "mesh_segmentation_demo.ipynb",
-      "private_outputs": true,
-      "provenance": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 2",
-      "name": "python2"
-    }
-  },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  ]
 }

--- a/tensorflow_graphics/notebooks/non_rigid_deformation.ipynb
+++ b/tensorflow_graphics/notebooks/non_rigid_deformation.ipynb
@@ -64,7 +64,7 @@
         "\n",
         "![](https://storage.googleapis.com/tensorflow-graphics/notebooks/non_rigid_deformation/task.jpg)\n",
         "\n",
-        "This notebook illustrates how to use [Tensorflow Graphics](https://github.com/tensorflow/graphics) to perform defomations simliar to the one contained in the above image. "
+        "This notebook illustrates how to use [Tensorflow Graphics](https://github.com/tensorflow/graphics) to perform deformations similiar to the one contained in the above image. "
       ]
     },
     {
@@ -75,16 +75,6 @@
       },
       "source": [
         "## Setup \u0026 Imports\n",
-        "\n",
-        "To run this Colab optimally, please update the runtime type to Python 3. \n",
-        "- click on the 'Runtime' menu, then 'Change runtime type':\n",
-        "\n",
-        "![](https://storage.googleapis.com/tensorflow-graphics/notebooks/non_rigid_deformation/change_runtime.jpg)\n",
-        "\n",
-        "- finally, set the 'Runtime type' to 'Python 3'.\n",
-        "\n",
-        "![](https://storage.googleapis.com/tensorflow-graphics/notebooks/non_rigid_deformation/select_python3.jpg)\n",
-        "\n",
         "\n",
         "If Tensorflow Graphics is not installed on your system, the following cell can install the Tensorflow Graphics package for you."
       ]
@@ -185,7 +175,7 @@
         "###############\n",
         "# UI controls #\n",
         "###############\n",
-        "#@title Contraints on the deformed pose { vertical-output: false, run: \"auto\" }\n",
+        "#@title Constraints on the deformed pose { vertical-output: false, run: \"auto\" }\n",
         "constraint_1_z = 0  #@param { type: \"slider\", min: -1, max: 1 , step: 0.05 }\n",
         "constraint_2_z = -1  #@param { type: \"slider\", min: -1, max: 1 , step: 0.05 }\n",
         "constraint_3_z = 0  #@param { type: \"slider\", min: -1, max: 1 , step: 0.05 }\n",
@@ -194,7 +184,7 @@
         "vertices_deformed_pose = np.copy(mesh_rest_pose['vertices'])\n",
         "num_vertices = vertices_deformed_pose.shape[0]\n",
         "\n",
-        "# Adds the user-defined constaints\n",
+        "# Adds the user-defined constraints\n",
         "vertices_deformed_pose[0, 2] = constraint_1_z\n",
         "vertices_deformed_pose[num_vertices // 2, 2] = constraint_1_z\n",
         "vertices_deformed_pose[num_vertices // 4, 2] = constraint_2_z\n",
@@ -291,8 +281,8 @@
       "version": "0.3.2"
     },
     "kernelspec": {
-      "display_name": "Python 2",
-      "name": "python2"
+      "display_name": "Python 3",
+      "name": "python3"
     }
   },
   "nbformat": 4,

--- a/tensorflow_graphics/notebooks/reflectance.ipynb
+++ b/tensorflow_graphics/notebooks/reflectance.ipynb
@@ -59,7 +59,7 @@
         "id": "N78wnH25iV5m"
       },
       "source": [
-        "The world around us is very complex and is made of a wide array of materials ranging from glass to wood. Each material possesses its own intrinsic properties and interacts differently with light. For instance, some are diffuse (e.g. paper or marble) and given a lighting condition, look the same from any angle. Other materials (e.g. metal) have an appearance that can vary significanly and exhibit view dependent effects such as specularities.\n",
+        "The world around us is very complex and is made of a wide array of materials ranging from glass to wood. Each material possesses its own intrinsic properties and interacts differently with light. For instance, some are diffuse (e.g. paper or marble) and given a lighting condition, look the same from any angle. Other materials (e.g. metal) have an appearance that can vary significantly and exhibit view dependent effects such as specularities.\n",
         "\n",
         "Modelling exactly how light interacts with materials is a complex process that involves effects like sub-surface scattering (e.g. skin) and refraction (e.g. water). In this Colab, we focus on the most common effect which is reflection. [Bidirectional reflectance distribution functions (BRDF)](https://en.wikipedia.org/wiki/Bidirectional_reflectance_distribution_function) is the method of choice when it comes to modelling reflectance. Given the direction of incoming light, BRDFs control the amount of light that bounces in the direction the surface is being observed (any gray vector in the image below).\n",
         "\n",
@@ -257,7 +257,7 @@
         "radiance = np.minimum(radiance, 1.0)\n",
         "radiance_lambertian = np.minimum(radiance_lambertian, 1.0)\n",
         "radiance_phong = np.minimum(radiance_phong, 1.0)\n",
-        "# Gammma correction\n",
+        "# Gamma correction\n",
         "radiance = np.power(radiance, 1.0 / 2.2)\n",
         "radiance_lambertian = np.power(radiance_lambertian, 1.0 / 2.2)\n",
         "radiance_phong = np.power(radiance_phong, 1.0 / 2.2)\n",
@@ -306,8 +306,8 @@
       "version": "0.3.2"
     },
     "kernelspec": {
-      "display_name": "Python 2",
-      "name": "python2"
+      "display_name": "Python 3",
+      "name": "python3"
     }
   },
   "nbformat": 4,

--- a/tensorflow_graphics/notebooks/spherical_harmonics_approximation.ipynb
+++ b/tensorflow_graphics/notebooks/spherical_harmonics_approximation.ipynb
@@ -601,8 +601,8 @@
       "version": "0.3.2"
     },
     "kernelspec": {
-      "display_name": "Python 2",
-      "name": "python2"
+      "display_name": "Python 3",
+      "name": "python3"
     }
   },
   "nbformat": 4,

--- a/tensorflow_graphics/notebooks/spherical_harmonics_optimization.ipynb
+++ b/tensorflow_graphics/notebooks/spherical_harmonics_optimization.ipynb
@@ -204,7 +204,7 @@
         "phi = spherical_coordinates[:, :, 2]\n",
         "\n",
         "################################################################################################\n",
-        "# Builds the Spherical Harmonics and set coefficients for the light and reflectance functions. #\n",
+        "# Builds the Spherical Harmonics and sets coefficients for the light and reflectance functions. #\n",
         "################################################################################################\n",
         "max_band = 2\n",
         "l, m = spherical_harmonics.generate_l_m_permutations(max_band)\n",
@@ -405,8 +405,8 @@
       "toc_visible": true
     },
     "kernelspec": {
-      "display_name": "Python 2",
-      "name": "python2"
+      "display_name": "Python 3",
+      "name": "python3"
     }
   },
   "nbformat": 4,

--- a/tensorflow_graphics/util/data_formats/__init__.py
+++ b/tensorflow_graphics/util/data_formats/__init__.py
@@ -24,8 +24,8 @@ try:
 except ImportError:
   print(
       "Warning: To use the exr data format, please install the OpenEXR"
-      " package following the instructions detailed in the README at"
-      " github.com/tensorflow/graphics.",
+      " package following the instructions detailed at"
+      " tensorflow.org/graphics/install.",
       file=sys.stderr)
 # pylint: enable=g-import-not-at-top
 


### PR DESCRIPTION
- changed warning when OpenEXR is missing because there's actually no info about it in README file. Another way would be to add it there and leave warning as it is.
- updated notebooks to use Python 3 as default (and removed instruction on how to change Colab runtime to Python 3 from [this](https://github.com/tensorflow/graphics/blob/master/tensorflow_graphics/notebooks/non_rigid_deformation.ipynb) notebook as it's no longer needed)
- fixed TF2 incompatibility in [example](https://github.com/tensorflow/graphics/blob/master/tensorflow_graphics/g3doc/_index.ipynb) at tensorflow.org/graphics
- added Colab/Github links to Mesh Segmentation [notebook](https://github.com/tensorflow/graphics/blob/master/tensorflow_graphics/notebooks/mesh_segmentation_demo.ipynb)
- some typos