### PR TITLE
Added keras serialization

### DIFF
--- a/tensorflow_graphics/nn/layer/graph_convolution.py
+++ b/tensorflow_graphics/nn/layer/graph_convolution.py
@@ -138,6 +138,7 @@ def feature_steered_convolution_layer(
         name=name)
 
 
+@tf.keras.utils.register_keras_serializable("Graphics")
 class FeatureSteeredConvolutionKerasLayer(tf.keras.layers.Layer):
   """Wraps the function `feature_steered_convolution` as a Keras layer."""
 
@@ -171,7 +172,17 @@ class FeatureSteeredConvolutionKerasLayer(tf.keras.layers.Layer):
     if initializer is None:
       self._initializer = tf.compat.v1.truncated_normal_initializer(stddev=0.1)
     else:
-      self._initializer = initializer
+      self._initializer = tf.keras.initializers.get(initializer)
+  
+  def get_config(self):
+    config = super().get_config()
+    config.update(dict(
+      translation_invariant=self._translation_invariant,
+      num_weight_matrices=self._num_weight_matrices,
+      num_output_channels=self._num_output_channels,
+      initializer=tf.keras.utils.serialize_keras_object(self._initializer),
+    ))
+    return config
 
   def build(self, input_shape):
     """Initializes the trainable weights."""
@@ -268,6 +279,7 @@ class FeatureSteeredConvolutionKerasLayer(tf.keras.layers.Layer):
         var_b=self.var_b)
 
 
+@tf.keras.utils.register_keras_serializable("Graphics")
 class DynamicGraphConvolutionKerasLayer(tf.keras.layers.Layer):
   """A keras layer for dynamic graph convolutions.
 
@@ -331,15 +343,35 @@ class DynamicGraphConvolutionKerasLayer(tf.keras.layers.Layer):
         name=name, **kwargs)
     self._num_output_channels = num_output_channels
     self._reduction = reduction
-    self._activation = activation
+    self._activation = tf.keras.activations.get(activation)
     self._use_bias = use_bias
-    self._kernel_initializer = kernel_initializer
-    self._bias_initializer = bias_initializer
-    self._kernel_regularizer = kernel_regularizer
-    self._bias_regularizer = bias_regularizer
-    self._activity_regularizer = activity_regularizer
-    self._kernel_constraint = kernel_constraint
-    self._bias_constraint = bias_constraint
+    self._kernel_initializer = tf.keras.initializers.get(kernel_initializer)
+    self._bias_initializer = tf.keras.initializers.get(bias_initializer)
+    self._kernel_regularizer = tf.keras.regularizers.get(kernel_regularizer)
+    self._bias_regularizer = tf.keras.regularizers.get(bias_regularizer)
+    self._activity_regularizer = tf.keras.regularizers.get(activity_regularizer)
+    self._kernel_constraint = tf.keras.constraints.get(kernel_constraint)
+    self._bias_constraint = tf.keras.constraints.get(bias_constraint)
+  
+  def get_config(self):
+    config = super().get_config()
+    config.update(dict(
+      num_output_channels=self._num_output_channels,
+      reduction=self._reduction,
+      activation=tf.keras.utils.serialize_keras_object(self._activation),
+      use_bias=self._use_bias,
+      kernel_initializer=tf.keras.utils.serialize_keras_object(
+        self._kernel_initializer),
+      bias_initializer=tf.keras.utils.serialize_keras_object(self._bias_initializer),
+      kernel_regularizer=tf.keras.utils.serialize_keras_object(
+        self._kernel_regularizer),
+      bias_regularizer=tf.keras.utils.serialize_keras_object(self._bias_regularizer),
+      activity_regularizer=tf.keras.utils.serialize_keras_object(
+        self._activity_regularizer),
+      kernel_constraint=tf.keras.utils.serialize_keras_object(self._kernel_constraint),
+      bias_constraint=tf.keras.utils.serialize_keras_object(self._bias_constraint),
+    ))
+    return config
 
   def build(self, input_shape):
     """Initializes the layer weights."""

--- a/tensorflow_graphics/nn/layer/graph_convolution.py
+++ b/tensorflow_graphics/nn/layer/graph_convolution.py
@@ -173,9 +173,9 @@ class FeatureSteeredConvolutionKerasLayer(tf.keras.layers.Layer):
       self._initializer = tf.compat.v1.truncated_normal_initializer(stddev=0.1)
     else:
       self._initializer = tf.keras.initializers.get(initializer)
-  
+
   def get_config(self):
-    config = super().get_config()
+    config = super(FeatureSteeredConvolutionKerasLayer, self).get_config()
     config.update(dict(
       translation_invariant=self._translation_invariant,
       num_weight_matrices=self._num_weight_matrices,
@@ -352,9 +352,9 @@ class DynamicGraphConvolutionKerasLayer(tf.keras.layers.Layer):
     self._activity_regularizer = tf.keras.regularizers.get(activity_regularizer)
     self._kernel_constraint = tf.keras.constraints.get(kernel_constraint)
     self._bias_constraint = tf.keras.constraints.get(bias_constraint)
-  
+
   def get_config(self):
-    config = super().get_config()
+    config = super(DynamicGraphConvolutionKerasLayer, self).get_config()
     config.update(dict(
       num_output_channels=self._num_output_channels,
       reduction=self._reduction,

--- a/tensorflow_graphics/nn/layer/tests/graph_convolution_test.py
+++ b/tensorflow_graphics/nn/layer/tests/graph_convolution_test.py
@@ -190,6 +190,17 @@ class GraphConvolutionTestFeatureSteeredConvolutionLayerTests(
         sess.run(tf.compat.v1.initialize_all_variables())
         for _ in range(num_training_iterations):
           sess.run(train_op)
+    
+  def test_layer_serialization(self):
+    layer = gc_layer.FeatureSteeredConvolutionKerasLayer(
+      num_weight_matrices=9, num_output_channels=17, initializer='glorot_normal')
+    serialized = tf.keras.utils.serialize_keras_object(layer)
+    deserialized = tf.keras.utils.deserialize_keras_object(serialized)
+    deserialized.build(((None, 3), (None, 2)))
+    config = deserialized.get_config()
+    self.assertEqual(config['num_weight_matrices'], 9)
+    self.assertEqual(config['num_output_channels'], 17)
+    self.assertEqual(config['initializer']['class_name'], 'GlorotNormal')
 
 
 class GraphConvolutionTestDynamicGraphConvolutionKerasLayerTests(
@@ -294,6 +305,19 @@ class GraphConvolutionTestDynamicGraphConvolutionKerasLayerTests(
         grads = tape.gradient(loss, trainable_variables)
         tf.compat.v1.train.GradientDescentOptimizer(1e-4).apply_gradients(
             zip(grads, trainable_variables))
+  
+  def test_layer_serialization(self):
+    layer = gc_layer.DynamicGraphConvolutionKerasLayer(
+      activation=tf.nn.relu, reduction='weighted', num_output_channels=17,
+      kernel_initializer='glorot_normal')
+    serialized = tf.keras.utils.serialize_keras_object(layer)
+    deserialized = tf.keras.utils.deserialize_keras_object(serialized)
+    deserialized.build(((None, 3), (None, 2)))
+    config = deserialized.get_config()
+    self.assertEqual(config['activation'], 'relu')
+    self.assertEqual(config['reduction'], 'weighted')
+    self.assertEqual(config['num_output_channels'], 17)
+    self.assertEqual(config['kernel_initializer']['class_name'], 'GlorotNormal')
 
 if __name__ == "__main__":
   test_case.main()

--- a/tensorflow_graphics/nn/layer/tests/graph_convolution_test.py
+++ b/tensorflow_graphics/nn/layer/tests/graph_convolution_test.py
@@ -190,7 +190,7 @@ class GraphConvolutionTestFeatureSteeredConvolutionLayerTests(
         sess.run(tf.compat.v1.initialize_all_variables())
         for _ in range(num_training_iterations):
           sess.run(train_op)
-    
+
   def test_layer_serialization(self):
     layer = gc_layer.FeatureSteeredConvolutionKerasLayer(
       num_weight_matrices=9, num_output_channels=17, initializer='glorot_normal')
@@ -305,7 +305,7 @@ class GraphConvolutionTestDynamicGraphConvolutionKerasLayerTests(
         grads = tape.gradient(loss, trainable_variables)
         tf.compat.v1.train.GradientDescentOptimizer(1e-4).apply_gradients(
             zip(grads, trainable_variables))
-  
+
   def test_layer_serialization(self):
     layer = gc_layer.DynamicGraphConvolutionKerasLayer(
       activation=tf.nn.relu, reduction='weighted', num_output_channels=17,


### PR DESCRIPTION
`register_keras_serializable` isn't available until 2.1. I'm unsure of the lower bound on supported versions, but this can be replaced with older-style `custom_objects` at call-sites or perhaps a `graphics_custom_object_scope`.

Package name `"Graphics"` was chosen based on tensorflow Addons' use of `"Addons"`