### PR TITLE
added tf mesh utils implementations

### DIFF
--- a/tensorflow_graphics/geometry/representation/mesh/tests/utils_tf_test.py
+++ b/tensorflow_graphics/geometry/representation/mesh/tests/utils_tf_test.py
@@ -1,0 +1,121 @@
+#Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for utils."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from absl.testing import parameterized
+import tensorflow as tf
+import numpy as np
+
+from tensorflow_graphics.geometry.representation.mesh import utils_tf
+from tensorflow_graphics.util import test_case
+
+
+class UtilsTfTest(test_case.TestCase):
+
+  @parameterized.parameters(
+      (np.array(((0, 1, 2),)), [[0, 1], [1, 2], [2, 0]]),
+      (np.array(
+          ((0, 1, 2), (0, 1, 3))), [[0, 1], [1, 2], [2, 0], [1, 3], [3, 0]]),
+  )
+  def test_extract_undirected_edges_from_triangular_mesh_preset(
+      self, test_inputs, test_outputs):
+    """Tests that the output contain the expected edges."""
+    num_vertices = tf.math.reduce_max(test_inputs) + 1
+    edges = utils_tf.extract_unique_edges_from_triangular_mesh(
+        test_inputs, num_vertices, directed_edges=False)
+    self.assertAllEqual(self.evaluate(edges), test_outputs)
+
+  @parameterized.parameters(
+      (np.array(
+          ((0, 1, 2),)), [[0, 1], [1, 2], [2, 0], [1, 0], [2, 1], [0, 2]]),
+      (np.array(
+          ((0, 1, 2), (0, 1, 3))), [[0, 1], [1, 2], [2, 0], [1, 3], [3, 0],
+                                    [1, 0], [2, 1], [0, 2], [3, 1], [0, 3]]),
+  )
+  def test_extract_directed_edges_from_triangular_mesh_preset(
+      self, test_inputs, test_outputs):
+    """Tests that the output contain the expected edges."""
+    num_vertices = tf.math.reduce_max(test_inputs) + 1
+    edges = utils_tf.extract_unique_edges_from_triangular_mesh(
+        test_inputs, num_vertices, directed_edges=True)
+    self.assertAllEqual(self.evaluate(edges), test_outputs)
+
+  @parameterized.parameters(
+      (1, "must have a rank equal to 2"),
+      (np.array((1,)), "must have a rank equal to 2"),
+      (np.array((((1,),),)), "must have a rank equal to 2"),
+      (np.array(((1,),)), "must have exactly 3 dimensions in the last axis"),
+      (np.array(((1, 1),)), "must have exactly 3 dimensions in the last axis"),
+      (np.array(
+          ((1, 1, 1, 1),)), "must have exactly 3 dimensions in the last axis"),
+  )
+  def test_extract_edges_from_triangular_mesh_raised(
+      self, invalid_input, error_msg):
+    """Tests that the shape exceptions are properly raised."""
+    with self.assertRaisesRegexp(ValueError, error_msg):
+      num_vertices = tf.math.reduce_max(invalid_input) + 1
+      utils_tf.extract_unique_edges_from_triangular_mesh(invalid_input, num_vertices)
+
+  @parameterized.parameters(
+      (np.array(((0, 1), (0, 2), (1, 0), (1, 2), (2, 0), (2, 1))),
+       tf.float16,
+       [0.5, 0.5, 0.5, 0.5, 0.5, 0.5]),
+      (np.array(((0, 1), (0, 2), (1, 0), (1, 2), (2, 0), (2, 1))),
+       tf.float32,
+       [0.5, 0.5, 0.5, 0.5, 0.5, 0.5]),
+      (np.array(((0, 1), (0, 2), (0, 3), (1, 0), (1, 2), (1, 3),
+                 (2, 0), (2, 1), (3, 0), (3, 1))),
+       tf.float64,
+       [1.0 / 3, 1.0 / 3, 1.0 / 3, 1.0 / 3, 1.0 / 3, 1.0 / 3,
+        0.5, 0.5, 0.5, 0.5]),
+  )
+  def test_get_degree_based_edge_weights_preset(
+      self, test_inputs, test_dtype, test_outputs):
+    """Tests that the output contain the expected edges."""
+    weights = utils_tf.get_degree_based_edge_weights(test_inputs, test_dtype)
+    self.assertAllClose(self.evaluate(weights), test_outputs)
+
+  @parameterized.parameters(
+      (1, "must have a rank equal to 2"),
+      (np.array((1,)), "must have a rank equal to 2"),
+      (np.array((((1,),),)), "must have a rank equal to 2"),
+      (np.array(((1,),)), "must have exactly 2 dimensions in the last axis"),
+      (np.array(
+          ((1, 1, 1),)), "must have exactly 2 dimensions in the last axis"),
+  )
+  def test_get_degree_based_edge_weights_invalid_edges_raised(
+      self, invalid_input, error_msg):
+    """Tests that the shape exceptions are properly raised."""
+    with self.assertRaisesRegexp(ValueError, error_msg):
+      utils_tf.get_degree_based_edge_weights(invalid_input)
+
+  @parameterized.parameters(
+      (tf.bool, "'dtype' must be a tensorflow float type"),
+      (tf.int64, "'dtype' must be a tensorflow float type"),
+      (tf.complex64, "'dtype' must be a tensorflow float type"),
+      (tf.uint64, "'dtype' must be a tensorflow float type"),
+      (tf.int16, "'dtype' must be a tensorflow float type"),
+  )
+  def test_get_degree_based_edge_weights_dtype_raised(
+      self, invalid_type, error_msg):
+    """Tests that the shape exceptions are properly raised."""
+    with self.assertRaisesRegexp(ValueError, error_msg):
+      utils_tf.get_degree_based_edge_weights(np.array(((1, 1),)), invalid_type)
+
+if __name__ == "__main__":
+  test_case.main()

--- a/tensorflow_graphics/geometry/representation/mesh/utils_tf.py
+++ b/tensorflow_graphics/geometry/representation/mesh/utils_tf.py
@@ -1,0 +1,127 @@
+"""This module implements similar functions to utils in pure tensorfow."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+
+from tensorflow_graphics.util import export_api
+
+
+def extract_unique_edges_from_triangular_mesh(
+        faces, num_vertices, directed_edges=False, name=None):
+  """Extracts all the unique edges using the faces of a mesh.
+
+  Args:
+    faces: A tensor of shape [T, 3], where T is the number of triangular
+      faces in the mesh. Each entry in this array describes the index of a
+      vertex in the mesh.
+    num_vertices: A scalar, total number of vertices in the mesh. All values in faces
+      must be less than this. Must be the same dtype as faces.
+    directed_edges: A boolean flag, whether to treat an edge as directed or
+      undirected.  If (i, j) is an edge in the mesh and directed_edges is True,
+      then both (i, j) and (j, i) are returned in the list of edges.
+      If (i, j) is an edge in the mesh and directed_edges is False,
+      then one of (i, j) or (j, i) is returned.
+    name: A name for this op. Defaults to
+      `extract_unique_edges_from_triangular_mesh`.
+
+
+  Returns:
+    A tensor of shape [E, 2], where E is the number of edges in
+    the mesh.
+
+
+    For eg: given faces = [[0, 1, 2], [0, 1, 3]], then
+      for directed_edges = False, one valid output is
+        [[0, 1], [0, 2], [0, 3], [1, 2], [3, 1]]
+      for directed_edges = True, one valid output is
+        [[0, 1], [0, 2], [0, 3], [1, 0], [1, 2], [1, 3],
+         [2, 0], [2, 1], [3, 0], [3, 1]]
+
+
+  Raises:
+    ValueError: If `faces` of `num_vertices` shape or dtype is not supported.
+  """
+  with tf.compat.v1.name_scope(
+      name, "graph_convolution_feature_steered_convolution", [faces, num_vertices]):
+    faces = tf.convert_to_tensor(faces)
+    num_vertices = tf.convert_to_tensor(num_vertices, dtype=faces.dtype)
+    if faces.shape.ndims != 2:
+      raise ValueError(
+            "'faces' must have a rank equal to 2, but it has rank {} and shape {}."
+            .format(faces.shape.ndims, faces.shape))
+    if faces.shape[1] != 3:
+      raise ValueError(
+          "'faces' must have exactly 3 dimensions in the last axis, but it has {}"
+          " dimensions and is of shape {}."
+          .format(faces.shape[1], faces.shape))
+    if not faces.dtype.is_integer:
+      raise ValueError(
+        "'faces' must have integer type but has dtype {}".format(faces.dtype))
+    if num_vertices.shape.ndims != 0:
+        raise ValueError(
+        "'num_vertices' must be a scalar but it has shape {}"
+        .format(num_vertices.dtype))
+    rolled_faces = tf.roll(faces, shift=-1, axis=1)
+    # we could make indices by stacking faces and rolled faces
+    # but unique requires our tensor to be 1D, so we'll ravel the index
+    # that means there's no need to stack in the first place
+    i = tf.reshape(faces, (-1, ))
+    j = tf.reshape(rolled_faces, (-1, ))
+    ravelled = i * num_vertices + j
+    unique, _ = tf.unique(ravelled)
+    indices = tf.unravel_index(unique, (num_vertices, num_vertices))
+    indices = tf.transpose(indices, (1, 0))
+    if directed_edges:
+      indices = tf.concat((indices, tf.reverse(indices, axis=[1])), axis=0)
+    return indices
+
+
+def get_degree_based_edge_weights(edges, dtype=tf.float32, name=None):
+  r"""Computes vertex degree based weights for edges of a mesh.
+
+  The degree (valence) of a vertex is number of edges incident on the vertex.
+  The weight for an edge $w_{ij}$ connecting vertex $v_i$ and vertex $v_j$
+  is defined as,
+  $$
+  w_{ij} = 1.0 / degree(v_i)
+  \sum_{j} w_{ij} = 1
+  $$
+
+  Args:
+    edges: An int tensor of shape [E, 2],
+      where E is the number of directed edges in the mesh.
+    dtype: A float dtype. The output weights are of data type dtype.
+    name: A name for this op. Defaults to `degree_based_edge_weights`.
+
+  Returns:
+    weights: A dtype tensor of shape [E,] denoting edge weights.
+
+  Raises:
+    ValueError: If `edges` is not of a supported type / shape, or dtype is
+        not a floating dtype.
+  """
+  if not dtype.is_floating:
+    raise ValueError("'dtype' must be a tensorflow float type.")
+  with tf.compat.v1.name_scope(name, "degree_based_edge_weights", [edges]):
+    edges = tf.convert_to_tensor(edges)
+    if not edges.dtype.is_integer:
+      raise ValueError(
+        "'edges' must have an integer dtype but it is {}".format(edges.dtype))
+    if edges.shape.ndims != 2:
+      raise ValueError(
+          "'edges' must have a rank equal to 2, but it has rank {} and shape {}."
+          .format(edges.shape, edges.shape.ndims))
+    if edges.shape[1] != 2:
+      raise ValueError(
+        "'edges' must have exactly 2 dimensions in the last axis, but it has {}"
+        " dimensions and is of shape {}."
+        .format(edges.shape[1], edges.shape))
+    _, index, counts = tf.unique_with_counts(edges[:, 0])
+    return 1. / tf.cast(tf.gather(counts, index), dtype)
+
+
+# API contains all public functions and classes.
+__all__ = export_api.get_functions_and_classes()

--- a/tensorflow_graphics/geometry/representation/mesh/utils_tf.py
+++ b/tensorflow_graphics/geometry/representation/mesh/utils_tf.py
@@ -59,11 +59,11 @@ def extract_unique_edges_from_triangular_mesh(
           .format(faces.shape[1], faces.shape))
     if not faces.dtype.is_integer:
       raise ValueError(
-        "'faces' must have integer type but has dtype {}".format(faces.dtype))
+          "'faces' must have integer type but has dtype {}".format(faces.dtype))
     if num_vertices.shape.ndims != 0:
-        raise ValueError(
-        "'num_vertices' must be a scalar but it has shape {}"
-        .format(num_vertices.dtype))
+      raise ValueError(
+          "'num_vertices' must be a scalar but it has shape {}"
+          .format(num_vertices.dtype))
     rolled_faces = tf.roll(faces, shift=-1, axis=1)
     # we could make indices by stacking faces and rolled faces
     # but unique requires our tensor to be 1D, so we'll ravel the index

--- a/tensorflow_graphics/notebooks/mesh_segmentation_dataio.py
+++ b/tensorflow_graphics/notebooks/mesh_segmentation_dataio.py
@@ -258,7 +258,7 @@ def _parse_mesh_data(mesh_data, mean_center=True):
   if mean_center:
     vertices = vertices - tf.reduce_mean(
         input_tensor=vertices, axis=0, keepdims=True)
-  
+
   num_vertices = tf.cast(mesh_data['num_vertices'], tf.int32)
   num_triangles = tf.cast(mesh_data['num_triangles'], tf.int32)
 


### PR DESCRIPTION
Not sure if these are wanted, where or how to name them, but I saw the `py_function` in the data pipeline and couldn't do nothing. Functionality is -almost- identical, though the ordering of edges is slightly different and there's a `range` instead of a `tf.unique` for some self-edges.