### PR TITLE
Remove mentioning eager execution

### DIFF
--- a/tensorflow_graphics/g3doc/_index.ipynb
+++ b/tensorflow_graphics/g3doc/_index.ipynb
@@ -86,7 +86,7 @@
         "id": "St8jfrN0MfPs"
       },
       "source": [
-        "Now that Tensorflow Graphics and Trimesh are installed, let's import everything needed and enable eager execution to display the output as we go."
+        "Now that Tensorflow Graphics and Trimesh are installed, let's import everything needed."
       ]
     },
     {


### PR DESCRIPTION
It's enabled by default now and the line enabling it was removed in https://github.com/tensorflow/graphics/commit/7b55d8a332be62bdc32c575c8c43d62fabc8be3d.