### PR TITLE
Pointnet mock data test

### DIFF
--- a/tensorflow_graphics/datasets/testing/__init__.py
+++ b/tensorflow_graphics/datasets/testing/__init__.py
@@ -1,0 +1,4 @@
+"""Data directory for testing datasets and projects dependent on them."""
+import os
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), 'metadata')

--- a/tensorflow_graphics/datasets/testing/metadata/model_net40/1.0.0/dataset_info.json
+++ b/tensorflow_graphics/datasets/testing/metadata/model_net40/1.0.0/dataset_info.json
@@ -1,0 +1,105 @@
+{
+  "citation": "\n@inproceedings{qi2017pointnet,\n  title={Pointnet: Deep learning on point sets for 3d classification and segmentation},\n  author={Qi, Charles R and Su, Hao and Mo, Kaichun and Guibas, Leonidas J},\n  booktitle={Proceedings of the IEEE conference on computer vision and pattern recognition},\n  pages={652--660},\n  year={2017}\n}\n",
+  "description": "\nThe dataset contains point clouds sampling CAD models from 40 different categories.\nThe files have been retrieved from https://modelnet.cs.princeton.edu\n\nTo generate each example, the authors first uniformly sampled a modelnet40 mesh\nwith 10000 uniform samples, and then employed furthest point sampling to downsample\nto 2048 points. The procedure is explained [here](https://github.com/charlesq34/pointnet2/blob/master/tf_ops/sampling/tf_sampling.py)\n",
+  "location": {
+    "urls": [
+      "https://modelnet.cs.princeton.edu"
+    ]
+  },
+  "name": "model_net40",
+  "schema": {
+    "feature": [
+      {
+        "name": "label",
+        "type": "INT"
+      },
+      {
+        "name": "points",
+        "shape": {
+          "dim": [
+            {
+              "size": "2048"
+            },
+            {
+              "size": "3"
+            }
+          ]
+        },
+        "type": "FLOAT"
+      }
+    ]
+  },
+  "sizeInBytes": "435212151",
+  "splits": [
+    {
+      "name": "test",
+      "numShards": "1",
+      "shardLengths": [
+        "2468"
+      ],
+      "statistics": {
+        "features": [
+          {
+            "name": "label",
+            "numStats": {
+              "commonStats": {
+                "numNonMissing": "2468"
+              },
+              "max": 39.0
+            }
+          },
+          {
+            "name": "points",
+            "numStats": {
+              "commonStats": {
+                "numNonMissing": "2468"
+              },
+              "max": 0.9999974370002747,
+              "min": -0.9999753832817078
+            },
+            "type": "FLOAT"
+          }
+        ],
+        "numExamples": "2468"
+      }
+    },
+    {
+      "name": "train",
+      "numShards": "1",
+      "shardLengths": [
+        "4920",
+        "4920"
+      ],
+      "statistics": {
+        "features": [
+          {
+            "name": "label",
+            "numStats": {
+              "commonStats": {
+                "numNonMissing": "9840"
+              },
+              "max": 39.0
+            }
+          },
+          {
+            "name": "points",
+            "numStats": {
+              "commonStats": {
+                "numNonMissing": "9840"
+              },
+              "max": 0.9999983310699463,
+              "min": -0.9999980926513672
+            },
+            "type": "FLOAT"
+          }
+        ],
+        "numExamples": "9840"
+      }
+    }
+  ],
+  "supervisedKeys": {
+    "input": "points",
+    "output": "label"
+  },
+  "version": "1.0.0"
+}

--- a/tensorflow_graphics/projects/pointnet/helpers.py
+++ b/tensorflow_graphics/projects/pointnet/helpers.py
@@ -122,7 +122,8 @@ def setup_tensorboard(flags):
     return
 
   # --- Do not allow experiment with same name
-  assert not tf.io.gfile.exists(flags.logdir), \
+  assert (not tf.io.gfile.exists(flags.logdir) or
+          len(tf.io.gfile.listdir(flags.logdir)) == 0), \
     "CRITICAL: folder {} already exists".format(flags.logdir)
 
   # --- Log where summary can be found

--- a/tensorflow_graphics/projects/pointnet/train.py
+++ b/tensorflow_graphics/projects/pointnet/train.py
@@ -150,8 +150,8 @@ if not FLAGS.dryrun:
     pbar = tqdm(ds_train, leave=False, total=total, disable=not FLAGS.tqdm)
     for train_example in pbar:
       train(train_example)
-      best_accuracy = evaluate()
-      pbar.set_postfix_str("best accuracy: {:.3f}".format(best_accuracy))
+    best_accuracy = evaluate()
+    pbar.set_postfix_str("best accuracy: {:.3f}".format(best_accuracy))
 
   except KeyboardInterrupt:
     helpers.handle_keyboard_interrupt(FLAGS)

--- a/tensorflow_graphics/projects/pointnet/train.py
+++ b/tensorflow_graphics/projects/pointnet/train.py
@@ -16,9 +16,7 @@
 
 import tensorflow as tf
 
-import tensorflow_datasets as tfds
 from tqdm import tqdm
-from tensorflow_graphics.datasets import testing
 from tensorflow_graphics.datasets.modelnet40 import ModelNet40
 from tensorflow_graphics.nn.layer.pointnet import PointNetVanillaClassifier as PointNet
 from tensorflow_graphics.projects.pointnet import augment
@@ -128,42 +126,32 @@ def evaluate():
   return evaluate.best_accuracy
 
 
-# ------------------------------------------------------------------------------
-# ------------------------------------------------------------------------------
-# ------------------------------------------------------------------------------
+if not FLAGS.dryrun:
+  # ------------------------------------------------------------------------------
+  # ------------------------------------------------------------------------------
+  # ------------------------------------------------------------------------------
 
-def load_datasets():
-  """Load train / test datasets."""
-  train_dataset, info = ModelNet40.load(split="train", with_info=True)
+  ds_train, info = ModelNet40.load(split="train", with_info=True)
   num_examples = info.splits["train"].num_examples
-  train_dataset = train_dataset.shuffle(
+  ds_train = ds_train.shuffle(
       num_examples, reshuffle_each_iteration=True)
-  train_dataset = train_dataset.repeat(FLAGS.num_epochs)
-  train_dataset = train_dataset.batch(FLAGS.batch_size)
-  test_dataset = ModelNet40.load(split="test").batch(FLAGS.batch_size)
-  return train_dataset, test_dataset
+  ds_train = ds_train.repeat(FLAGS.num_epochs)
+  ds_train = ds_train.batch(FLAGS.batch_size)
+  ds_test = ModelNet40.load(split="test").batch(FLAGS.batch_size)
 
+  # ------------------------------------------------------------------------------
+  # ------------------------------------------------------------------------------
+  # ------------------------------------------------------------------------------
 
-if FLAGS.dryrun:
-  # use epochs with 2 batches of mocked data
-  with tfds.testing.mock_data(FLAGS.batch_size * 2, data_dir=testing.DATA_DIR):
-    ds_train, ds_test = load_datasets()
-else:
-  ds_train, ds_test = load_datasets()
+  try:
+    helpers.setup_tensorboard(FLAGS)
+    helpers.summary_command(parser, FLAGS)
+    total = tf.data.experimental.cardinality(ds_train).numpy()
+    pbar = tqdm(ds_train, leave=False, total=total, disable=not FLAGS.tqdm)
+    for train_example in pbar:
+      train(train_example)
+      best_accuracy = evaluate()
+      pbar.set_postfix_str("best accuracy: {:.3f}".format(best_accuracy))
 
-# ------------------------------------------------------------------------------
-# ------------------------------------------------------------------------------
-# ------------------------------------------------------------------------------
-
-try:
-  helpers.setup_tensorboard(FLAGS)
-  helpers.summary_command(parser, FLAGS)
-  total = tf.data.experimental.cardinality(ds_train).numpy()
-  pbar = tqdm(ds_train, leave=False, total=total, disable=not FLAGS.tqdm)
-  for train_example in pbar:
-    train(train_example)
-    best_accuracy = evaluate()
-    pbar.set_postfix_str("best accuracy: {:.3f}".format(best_accuracy))
-
-except KeyboardInterrupt:
-  helpers.handle_keyboard_interrupt(FLAGS)
+  except KeyboardInterrupt:
+    helpers.handle_keyboard_interrupt(FLAGS)

--- a/tensorflow_graphics/projects/pointnet/train.py
+++ b/tensorflow_graphics/projects/pointnet/train.py
@@ -38,7 +38,6 @@ parser.add("--ev_every", 308, help="evaluation frequency (iterations)")
 parser.add("--tfds", True, help="use TFDS dataset loader")
 parser.add("--augment", True, help="use augmentations")
 parser.add("--tqdm", True, help="enable the progress bar")
-parser.add_argument("--dryrun", action="store_true")
 FLAGS = parser.parse_args()
 
 # ------------------------------------------------------------------------------
@@ -126,32 +125,31 @@ def evaluate():
   return evaluate.best_accuracy
 
 
-if not FLAGS.dryrun:
-  # ------------------------------------------------------------------------------
-  # ------------------------------------------------------------------------------
-  # ------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 
-  ds_train, info = ModelNet40.load(split="train", with_info=True)
-  num_examples = info.splits["train"].num_examples
-  ds_train = ds_train.shuffle(
-      num_examples, reshuffle_each_iteration=True)
-  ds_train = ds_train.repeat(FLAGS.num_epochs)
-  ds_train = ds_train.batch(FLAGS.batch_size)
-  ds_test = ModelNet40.load(split="test").batch(FLAGS.batch_size)
+ds_train, info = ModelNet40.load(split="train", with_info=True)
+num_examples = info.splits["train"].num_examples
+ds_train = ds_train.shuffle(
+    num_examples, reshuffle_each_iteration=True)
+ds_train = ds_train.repeat(FLAGS.num_epochs)
+ds_train = ds_train.batch(FLAGS.batch_size)
+ds_test = ModelNet40.load(split="test").batch(FLAGS.batch_size)
 
-  # ------------------------------------------------------------------------------
-  # ------------------------------------------------------------------------------
-  # ------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 
-  try:
-    helpers.setup_tensorboard(FLAGS)
-    helpers.summary_command(parser, FLAGS)
-    total = tf.data.experimental.cardinality(ds_train).numpy()
-    pbar = tqdm(ds_train, leave=False, total=total, disable=not FLAGS.tqdm)
-    for train_example in pbar:
-      train(train_example)
+try:
+  helpers.setup_tensorboard(FLAGS)
+  helpers.summary_command(parser, FLAGS)
+  total = tf.data.experimental.cardinality(ds_train).numpy()
+  pbar = tqdm(ds_train, leave=False, total=total, disable=not FLAGS.tqdm)
+  for train_example in pbar:
+    train(train_example)
     best_accuracy = evaluate()
     pbar.set_postfix_str("best accuracy: {:.3f}".format(best_accuracy))
 
-  except KeyboardInterrupt:
-    helpers.handle_keyboard_interrupt(FLAGS)
+except KeyboardInterrupt:
+  helpers.handle_keyboard_interrupt(FLAGS)

--- a/tensorflow_graphics/projects/pointnet/train.py
+++ b/tensorflow_graphics/projects/pointnet/train.py
@@ -35,7 +35,6 @@ parser.add("--lr_decay", True, help="enable learning rate decay")
 parser.add("--bn_decay", .5, help="batch norm decay momentum")
 parser.add("--tb_every", 100, help="tensorboard frequency (iterations)")
 parser.add("--ev_every", 308, help="evaluation frequency (iterations)")
-parser.add("--tfds", True, help="use TFDS dataset loader")
 parser.add("--augment", True, help="use augmentations")
 parser.add("--tqdm", True, help="enable the progress bar")
 FLAGS = parser.parse_args()
@@ -131,8 +130,7 @@ def evaluate():
 
 ds_train, info = ModelNet40.load(split="train", with_info=True)
 num_examples = info.splits["train"].num_examples
-ds_train = ds_train.shuffle(
-    num_examples, reshuffle_each_iteration=True)
+ds_train = ds_train.shuffle(num_examples, reshuffle_each_iteration=True)
 ds_train = ds_train.repeat(FLAGS.num_epochs)
 ds_train = ds_train.batch(FLAGS.batch_size)
 ds_test = ModelNet40.load(split="test").batch(FLAGS.batch_size)

--- a/tensorflow_graphics/projects/pointnet/train_test.py
+++ b/tensorflow_graphics/projects/pointnet/train_test.py
@@ -16,21 +16,26 @@
 import sys
 import tempfile
 
+
+import tensorflow_datasets as tfds
 from tensorflow_graphics.util import test_case
+from tensorflow_graphics.datasets import testing
 
 
 class TrainTest(test_case.TestCase):
 
   def test_train(self):
-    with tempfile.TemporaryDirectory() as logdir:
-      sys.argv = [
-          "train.py",
-          "--num_epochs", "2",
-          "--assert_gpu", "False",
-          "--dryrun",
-          "--logdir", logdir
-          ]
-      import tensorflow_graphics.projects.pointnet.train  # pylint: disable=import-outside-toplevel, unused-import, g-import-not-at-top
+    batch_size = 8
+    with tfds.testing.mock_data(batch_size * 2, data_dir=testing.DATA_DIR):
+      with tempfile.TemporaryDirectory() as logdir:
+        sys.argv = [
+            "train.py",
+            "--num_epochs", "2",
+            "--assert_gpu", "False",
+            "--logdir", logdir,
+            "--batch_size", str(batch_size),
+            ]
+        import tensorflow_graphics.projects.pointnet.train  # pylint: disable=import-outside-toplevel, unused-import, g-import-not-at-top
 
 
 

--- a/tensorflow_graphics/projects/pointnet/train_test.py
+++ b/tensorflow_graphics/projects/pointnet/train_test.py
@@ -28,21 +28,17 @@ class TrainTest(test_case.TestCase):
     batch_size = 8
     with tfds.testing.mock_data(batch_size * 2, data_dir=testing.DATA_DIR):
       with tempfile.TemporaryDirectory() as logdir:
+        # yapf: disable
         sys.argv = [
             "train.py",
-            "--num_epochs",
-            "2",
-            "--assert_gpu",
-            "False",
-            "--ev_every",
-            "1",
-            "--tb_every",
-            "1",
-            "--logdir",
-            logdir,
-            "--batch_size",
-            str(batch_size),
+            "--num_epochs", "2",
+            "--assert_gpu", "False",
+            "--ev_every", "1",
+            "--tb_every", "1",
+            "--logdir", logdir,
+            "--batch_size", str(batch_size),
         ]
+        # yapf: enable
         importlib.import_module("tensorflow_graphics.projects.pointnet.train")
 
 

--- a/tensorflow_graphics/projects/pointnet/train_test.py
+++ b/tensorflow_graphics/projects/pointnet/train_test.py
@@ -24,11 +24,12 @@ class TrainTest(test_case.TestCase):
   def test_train(self):
     with tempfile.TemporaryDirectory() as logdir:
       sys.argv = [
-          *sys.argv,
+          "train.py",
           "--num_epochs", "2",
           "--assert_gpu", "False",
           "--dryrun",
-          "--logdir", logdir]
+          "--logdir", logdir
+          ]
       import tensorflow_graphics.projects.pointnet.train  # pylint: disable=import-outside-toplevel, unused-import, g-import-not-at-top
 
 

--- a/tensorflow_graphics/projects/pointnet/train_test.py
+++ b/tensorflow_graphics/projects/pointnet/train_test.py
@@ -30,13 +30,19 @@ class TrainTest(test_case.TestCase):
       with tempfile.TemporaryDirectory() as logdir:
         sys.argv = [
             "train.py",
-            "--num_epochs", "2",
-            "--assert_gpu", "False",
-            "--ev_every", "1",
-            "--tb_every", "1",
-            "--logdir", logdir,
-            "--batch_size", str(batch_size),
-            ]
+            "--num_epochs",
+            "2",
+            "--assert_gpu",
+            "False",
+            "--ev_every",
+            "1",
+            "--tb_every",
+            "1",
+            "--logdir",
+            logdir,
+            "--batch_size",
+            str(batch_size),
+        ]
         importlib.import_module("tensorflow_graphics.projects.pointnet.train")
 
 

--- a/tensorflow_graphics/projects/pointnet/train_test.py
+++ b/tensorflow_graphics/projects/pointnet/train_test.py
@@ -14,25 +14,23 @@
 """Tests of pointnet module."""
 
 import sys
-import tensorflow as tf
+import tempfile
 
 from tensorflow_graphics.util import test_case
-
-
-def make_fake_batch(dimension_1, dimension_2):
-  points = tf.random.normal((dimension_1, dimension_2, 3))
-  label = tf.random.uniform((dimension_1,), minval=0, maxval=40, dtype=tf.int32)
-  return {"points": points, "label": label}
 
 
 class TrainTest(test_case.TestCase):
 
   def test_train(self):
-    sys.argv = ["train.py", "--dryrun", "--assert_gpu", "False"]
-    from tensorflow_graphics.projects.pointnet import train  # pylint: disable=import-outside-toplevel, unused-import, g-import-not-at-top
-    for _ in range(2):
-      batch = make_fake_batch(32, 1024)
-      train.train(batch)
+    with tempfile.TemporaryDirectory() as logdir:
+      sys.argv = [
+          *sys.argv,
+          "--num_epochs", "2",
+          "--assert_gpu", "False",
+          "--dryrun",
+          "--logdir", logdir]
+      import tensorflow_graphics.projects.pointnet.train  # pylint: disable=import-outside-toplevel, unused-import, g-import-not-at-top
+
 
 
 if __name__ == "__main__":

--- a/tensorflow_graphics/projects/pointnet/train_test.py
+++ b/tensorflow_graphics/projects/pointnet/train_test.py
@@ -15,7 +15,7 @@
 
 import sys
 import tempfile
-
+import importlib
 
 import tensorflow_datasets as tfds
 from tensorflow_graphics.util import test_case
@@ -32,11 +32,12 @@ class TrainTest(test_case.TestCase):
             "train.py",
             "--num_epochs", "2",
             "--assert_gpu", "False",
+            "--ev_every", "1",
+            "--tb_every", "1",
             "--logdir", logdir,
             "--batch_size", str(batch_size),
             ]
-        import tensorflow_graphics.projects.pointnet.train  # pylint: disable=import-outside-toplevel, unused-import, g-import-not-at-top
-
+        importlib.import_module("tensorflow_graphics.projects.pointnet.train")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* `tfds.mock_data` requires dataset info, hence the `datasets/testing/metadata` subdirectory.
* Allowing empty directories is required even without  `--logdir` used in `argv`, since the default `--logdir` uses `mkdtemp` which creates the directory just like `TemporaryDirectory` (the use of `TemporaryDirectory` is purely to ensure things are cleaned up immediately afterwards). 