### PR TITLE
Visualization abstraction layer with support for photorealistic renderer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+*.ply
+*.blend
+*.png
+.DS_Store
 **/__pycache__/
 bazel-out
 bazel-testlogs

--- a/tensorflow_graphics/threejs/README.md
+++ b/tensorflow_graphics/threejs/README.md
@@ -1,0 +1,12 @@
+# example of threejs in colab
+https://github.com/tensorflow/graphics/blob/master/tensorflow_graphics/notebooks/mesh_viewer.py
+
+# derek's tutorial
+https://github.com/HTDerekLiu/BlenderToolbox/blob/master/cycles/tutorial.py
+
+# threejs starting example
+https://threejs.org/docs/#manual/en/introduction/Creating-a-scene
+
+# installing mathutils on blender's python (macOS)
+/Applications/Blender.app/Contents/Resources/2.83/python/bin/python3.7m -m pip install mathutils
+/Applications/Blender.app/Contents/Resources/2.83/python/bin/python3.7m -m pip install webcolors

--- a/tensorflow_graphics/threejs/__init__.py
+++ b/tensorflow_graphics/threejs/__init__.py
@@ -1,0 +1,26 @@
+# Copyright 2020 The TensorFlow Authors, Derek Liu
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The threejs-like API for TensorFlow Graphics."""
+
+from .object3d import Object3D
+from .scene import Scene
+from .renderers import BlenderRenderer
+from .cameras import PerspectiveCamera
+from .cameras import OrthographicCamera
+from .geometry import BoxGeometry
+from .materials import MeshBasicMaterial
+from .lights import AmbientLight
+from .lights import DirectionalLight
+from .mesh import Mesh
+from .mesh import InvisibleGround

--- a/tensorflow_graphics/threejs/cameras.py
+++ b/tensorflow_graphics/threejs/cameras.py
@@ -1,0 +1,53 @@
+# Copyright 2020 The TensorFlow Authors, Derek Liu
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+The cameras to be used by the rendering system
+
+See: 
+  https://threejs.org/docs/#api/en/cameras/Camera
+  https://docs.blender.org/api/current/bpy.types.Camera.html
+"""
+import tensorflow_graphics.threejs as THREE
+
+
+class Camera(THREE.Object3D):
+  def __init__(self):
+    self.zoom = 1
+
+  def update_projection_matrix(self):
+    # TODO: why is this needed by 3js? (assumption: performance)
+    pass
+
+
+class OrthographicCamera(Camera):
+  def __init__(self, left=-1, right=+1, top=+1, bottom=-1, near=.1, far=2000):
+    # TODO: how to set camera limits in blender?
+    super().__init__()
+
+  def blender(self):
+    import bpy
+    bpy.ops.object.camera_add(location=self.position) # name 'Camera'
+    cam = bpy.context.object
+    cam.data.type = 'ORTHO'
+    cam.data.ortho_scale = 1.0 / self.zoom
+    cam.rotation_euler = self.quaternion.to_euler()
+    return cam
+
+
+class PerspectiveCamera(Camera):
+  def __init__(self, fov=75, aspect=1, near=0.1, far=1000):
+    raise NotImplementedError
+
+  def blender(self):
+    raise NotImplementedError

--- a/tensorflow_graphics/threejs/geometry.py
+++ b/tensorflow_graphics/threejs/geometry.py
@@ -1,0 +1,52 @@
+# Copyright 2020 The TensorFlow Authors, Derek Liu
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" The geometry module of the threejs renderer."""
+import tensorflow_graphics.threejs as THREE
+
+
+# TODO: integrate https://docs.blender.org/api/current/bmesh.html ?
+
+class BoxGeometry(THREE.Object3D):
+  def __init__(self, width=1.0, height=1.0, depth=1.0, width_segments=1, height_segments=1, depth_segments=1):
+    super().__init__(self)
+    self.width = width
+    self.height = height
+    self.depth = depth
+    # TODO: properties are not used
+    self.width_segments = width_segments
+    self.height_segments = height_segments
+    self.depth_segments = depth_segments
+
+
+  def blender(self):
+    import bpy
+    bpy.ops.mesh.primitive_cube_add(location=self.position)
+    self._blender_object = bpy.context.active_object
+    # TODO: adding explicit names to elements might be nice? (Blender only)
+    # self._blender_object.name = "mycube"
+
+
+# TODO: should we add subdivision to the Geometry abstraction?
+# def subdivision(mesh, level = 0):
+# 	bpy.context.view_layer.objects.active = mesh
+# 	bpy.ops.object.modifier_add(type='SUBSURF')
+# 	mesh.modifiers["Subdivision"].render_levels = level # rendering subdivision level
+# 	mesh.modifiers["Subdivision"].levels = level # subdivision level in 3D view
+
+# TODO: straight from file loader
+# meshPath = "spot.ply"
+# location = (-0.3, 0.6, -0.04) # (UI: click mesh > Transform > Location)
+# rotation = (90, 0,0) # (UI: click mesh > Transform > Rotation)
+# scale = (1.5,1.5,1.5) # (UI: click mesh > Transform > Scale)
+# blender.read_ply(meshPath, location, rotation, scale)

--- a/tensorflow_graphics/threejs/helloworld.py
+++ b/tensorflow_graphics/threejs/helloworld.py
@@ -1,0 +1,63 @@
+# Copyright 2020 The TensorFlow Authors, Derek Liu
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" Helloworld for 3D visualization in Tensorflow Graphics.
+
+Inspired by https://threejs.org/docs/#manual/en/introduction/Creating-a-scene.
+
+WARNING: this needs to be executed in either of two ways
+  1) Via the python REPL inside blender as `blender --background --python helloworld.py`
+  2) Via `pip install bpy` via https://wiki.blender.org/wiki/Building_Blender/Other/BlenderAsPyModule
+"""
+
+# TODO: tensorflow_graphics is not installed in Blender's REPL
+import os, sys
+sys.path.append("/Users/atagliasacchi/dev/graphics")
+
+import tensorflow_graphics.threejs as THREE
+
+# --- setup the renderer
+renderer = THREE.BlenderRenderer()
+renderer.set_size(640,480)
+scene = THREE.Scene()
+
+# --- setup the camera
+camera = THREE.OrthographicCamera()
+camera.zoom = .1
+camera.position = (10, 10, 10)
+camera.up = (0, 0, 1)
+camera.look_at(0, 0, .5)
+camera.update_projection_matrix()
+
+# --- lights
+amb_light = THREE.AmbientLight(color=0x404040)
+scene.add(amb_light)
+# --- sun
+dir_light = THREE.DirectionalLight(color=0xffffff, intensity=2)
+dir_light.position = (10, 5, 10)
+dir_light.target.position = (0, 0, 0)
+scene.add(dir_light)
+
+# --- instantiate object
+geometry = THREE.BoxGeometry(1, 1, 1)
+geometry.position = (0, 0, 1.5)
+material = THREE.MeshBasicMaterial({"color": 0xFF0000})
+cube = THREE.Mesh(geometry, material)
+scene.add(cube)
+
+# --- transparent floow
+ground = THREE.InvisibleGround()
+scene.add(ground)
+
+# --- render to PNG or save .blend file (according to extension)
+renderer.render(scene, camera, path="helloworld.png")

--- a/tensorflow_graphics/threejs/lights.py
+++ b/tensorflow_graphics/threejs/lights.py
@@ -1,0 +1,71 @@
+# Copyright 2020 The TensorFlow Authors, Derek Liu
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import tensorflow_graphics.threejs as THREE
+
+
+def hex_to_rgba(hexint: int):
+  b = hexint & 255 
+  g = (hexint>>8) & 255
+  r = (hexint>>16) & 255
+  return (r/255.0, g/255.0, b/255.0, 1.0)
+
+
+class Light(THREE.Object3D):
+  def __init__(self, color=(0.1, 0.1, 0.1, 1.0), intensity=2):
+    self.color = color
+    self.intensity = intensity # TODO convert intensity into a property (check ranges)
+
+  @property
+  def color(self):
+    return self._color
+
+  @color.setter
+  def color(self, val):
+    self._color = hex_to_rgba(val)
+
+
+class AmbientLight(Light):
+  def __init__(self, color=(0.1, 0.1, 0.1, 1.0)):
+    self.color = color
+
+  def blender(self):
+    import bpy
+    bpy.data.scenes[0].world.use_nodes = True #< TODO: shouldn't use_nodes be moved to scene creator?
+    bpy.data.scenes[0].world.node_tree.nodes["Background"].inputs['Color'].default_value = self.color
+
+
+class DirectionalLight(Light):
+  # directional light uses a source/target (instead of just a direction) as the
+  # THREEJS backend uses this to create shadows via shadow-mapping
+
+  def __init__(self, color, intensity=2, shadow_softness=.1):
+    super().__init__(color, intensity)
+    self.target = THREE.Object3D()  # defaults to origin
+    self.intensity = intensity  #TODO: @property to check ranges
+    self.shadow_softness = shadow_softness #TODO: @property to check ranges
+
+  def blender(self):
+    print("TODO directional")
+    import bpy
+    x = self.target.position.x
+    y = self.target.position.y
+    z = self.target.position.z
+    self.look_at(x,y,z)
+    rotation = self.quaternion.to_euler()
+    bpy.ops.object.light_add(type='SUN', rotation=rotation, location=self.position)
+    lamp = bpy.data.lights['Sun']
+    lamp.use_nodes = True
+    lamp.angle = self.shadow_softness
+    lamp.node_tree.nodes["Emission"].inputs['Strength'].default_value = self.intensity
+    return lamp

--- a/tensorflow_graphics/threejs/materials.py
+++ b/tensorflow_graphics/threejs/materials.py
@@ -1,0 +1,26 @@
+# Copyright 2020 The TensorFlow Authors, Derek Liu
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+class Material():
+  pass
+
+class MeshBasicMaterial(Material):
+  def __init__(self, specs):
+    self.specs = specs
+
+  def blender(self):
+    # TODO: shading
+    import bpy
+    # bpy.ops.object.shade_smooth() # Option1: Gouraud shading
+    bpy.ops.object.shade_flat() # Option2: Flat shading
+    # edgeNormals(mesh, angle = 10) # Option3: Edge normal shading)

--- a/tensorflow_graphics/threejs/mesh.py
+++ b/tensorflow_graphics/threejs/mesh.py
@@ -1,0 +1,47 @@
+# Copyright 2020 The TensorFlow Authors, Derek Liu
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import tensorflow_graphics.threejs as THREE
+
+class Mesh(THREE.Object3D):
+  def __init__(self, geometry, material):
+    self.geometry = geometry
+    self.material = material
+
+  def blender(self):
+    self.geometry.blender()
+    self.material.blender()
+
+
+# TODO: this object merges a plane with a transparent material, should be factored into two components
+class InvisibleGround(Mesh):
+
+  def __init__(self, location=(0, 0, 0), size=20, shadow_brightness=.7 ):
+    self.location = location
+    self.size = size
+    self.shadow_brightness = shadow_brightness
+
+  def blender(self):
+    import bpy
+    bpy.context.scene.cycles.film_transparent = True  # TODO: this seems more appropriate in scene setup?
+    bpy.ops.mesh.primitive_plane_add(location=self.location, size=self.size)
+    bpy.context.object.cycles.is_shadow_catcher = True
+
+    # --- set material
+    ground = bpy.context.object
+    mat = bpy.data.materials.new('MeshMaterial')
+    ground.data.materials.append(mat)
+    mat.use_nodes = True
+    tree = mat.node_tree
+    tree.nodes["Principled BSDF"].inputs['Transmission'].default_value = self.shadow_brightness
+    return ground

--- a/tensorflow_graphics/threejs/object3d.py
+++ b/tensorflow_graphics/threejs/object3d.py
@@ -1,0 +1,44 @@
+# Copyright 2020 The TensorFlow Authors, Derek Liu
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import mathutils
+
+class Object3D(object):
+
+  def __init__(self, name=None):
+    self.name = name
+    self.parent = None
+    self._position = mathutils.Vector((0,0,0))
+    self.quaternion = mathutils.Quaternion().identity()
+    self.up = (0,1,0)
+    self.scale = (1,1,1)
+    self.receive_shadow = False
+    # self.cast_shadow = False
+
+  @property
+  def position(self):
+    return self._position
+
+  @position.setter
+  def position(self, val):
+    """Sets the position given a list of 3 elements."""
+    self._position = mathutils.Vector(val)
+
+  def look_at(self, x, y, z):
+    direction = mathutils.Vector((x,y,z)) - self.position
+    # TODO: we should be using self.up here?
+    self.quaternion = direction.to_track_quat('-Z', 'Y')
+    
+  # TODO: add inheritable blender() method
+  def blender(self):
+    print("not implemented!")

--- a/tensorflow_graphics/threejs/renderers.py
+++ b/tensorflow_graphics/threejs/renderers.py
@@ -1,0 +1,84 @@
+# Copyright 2020 The TensorFlow Authors, Derek Liu
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class Renderer(object):
+  """Superclass of all renderers."""
+  def __init__(self):
+    self.set_size()
+
+  def set_size(self, width: int=320, height: int=240):
+    self.width = width
+    self.height = height
+
+class BlenderRenderer(Renderer):
+
+  def __init__(self, numSamples = 128, exposure = 1.5, useBothCPUGPU = False):
+    super().__init__()
+    import bpy
+    # because blender has a default scene on load...
+    self.clear_scene()
+    # use cycle
+    bpy.context.scene.render.engine = 'CYCLES'
+    bpy.context.scene.render.resolution_x = self.width
+    bpy.context.scene.render.resolution_y = self.height
+    bpy.context.scene.render.film_transparent = True
+    # bpy.context.scene.cycles.film_transparent = True # TODO derek?
+    bpy.context.scene.cycles.samples = numSamples
+    bpy.context.scene.cycles.max_bounces = 6
+    bpy.context.scene.cycles.film_exposure = exposure
+    bpy.data.scenes[0].view_layers['View Layer']['cycles']['use_denoising'] = 1
+
+    # set devices # TODO derek?
+    cyclePref  = bpy.context.preferences.addons['cycles'].preferences
+    cyclePref.compute_device_type = 'CUDA'
+    for dev in cyclePref.devices:
+      if dev.type == "CPU" and useBothCPUGPU is False:
+        dev.use = False
+      else:
+        dev.use = True
+    bpy.context.scene.cycles.device = 'GPU'
+
+    for dev in cyclePref.devices:
+      print (dev)
+      print (dev.use)
+
+  def clear_scene(self):
+    import bpy
+    bpy.ops.wm.read_homefile()
+    bpy.ops.object.select_all(action = 'SELECT')
+    bpy.ops.object.delete()
+
+  def render(self, scene=None, camera=None, path=None):
+    assert path.endswith(".blend") or path.endswith(".png")
+    import bpy
+
+    # converts objects to blender mode
+    blender_camera = camera.blender()
+    scene.blender()
+
+    # creates blender file
+    if path.endswith(".blend"):
+      bpy.ops.wm.save_mainfile(filepath=path)
+    
+    # renders scene directly to file
+    if path.endswith(".png"):
+      bpy.data.scenes['Scene'].render.filepath = path
+      bpy.data.scenes['Scene'].camera = blender_camera
+      bpy.ops.render.render(write_still = True)
+
+
+class WebGLRenderer():
+  """This would be the colab-friendly renderer."""
+  def __init__(self):
+    raise NotImplementedError()

--- a/tensorflow_graphics/threejs/scene.py
+++ b/tensorflow_graphics/threejs/scene.py
@@ -1,0 +1,26 @@
+# Copyright 2020 The TensorFlow Authors, Derek Liu
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import tensorflow_graphics.threejs as THREE
+
+class Scene(object):
+
+  def __init__(self):
+    self._objects3d = list()
+
+  def add(self, object):  #< node? check 3js API
+    self._objects3d.append(object)
+
+  def blender(self):
+    for object3d in self._objects3d:
+      object3d.blender()

--- a/tensorflow_graphics/threejs/threejs_test.py
+++ b/tensorflow_graphics/threejs/threejs_test.py
@@ -1,0 +1,21 @@
+# Copyright 2020 The TensorFlow Authors
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import sys
+import pytest
+
+def test_helloworld():
+  print("hello")
+
+if __name__ == "__main__":
+  sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
**NOTE: this is currently a draft – not ready for integration**

The purpose of this is to create a **shared** abstraction layer for visualization so that:
- it can be used in jupyter-friendly (interactive) 3D renderers (WebGL) → easy to implement via threejs
- it can be used with photorealistic (not interactive) renderers (blender) → this draft implementation
- it can be used in local (interative) 3D renderers (OpenGL) → not implemented yet

See `tensorflow_graphics/threejs/helloworld.py` for an end to end example (blender backend) that generates this image:
![helloworld](https://user-images.githubusercontent.com/4480573/86051554-9aaef380-ba23-11ea-8e83-7b074b826376.png)

The photorealistic backend will also be used to generate synthetic training datasets.