### PR TITLE
Update comment of square_to_spherical_coordinates to reflect extra dim

### DIFF
--- a/tensorflow_graphics/math/math_helpers.py
+++ b/tensorflow_graphics/math/math_helpers.py
@@ -170,8 +170,8 @@ def square_to_spherical_coordinates(point_2d,
       "math_square_to_spherical_coordinates".
 
   Returns:
-    A tensor of shape `[A1, ..., An, 2]` with [..., 0] having values in
-    [0.0, pi] and [..., 1] with values in [0.0, 2pi].
+    A tensor of shape `[A1, ..., An, 3]` with [..., 1] having values in
+    [0.0, pi] and [..., 2] with values in [0.0, 2pi].
 
   Raises:
     ValueError: if the shape of `point_2d`  is not supported.


### PR DESCRIPTION
Hello there!

I found a small mistake in the doc of this square_to_spherical_coordinates. It returns [:,:,3] whereas the doc says [:,:,2], so did a quick fix there.
If there's any other way you'd prefer this change, please let me know. Thanks!