### PR TITLE
Improve performance

### DIFF
--- a/tensorflow_graphics/projects/points_to_3Dobjects/utils/evaluator.py
+++ b/tensorflow_graphics/projects/points_to_3Dobjects/utils/evaluator.py
@@ -588,6 +588,8 @@ class Evaluator:
     result_dict = {'iou_mean': -1, 'iou_min': -1, 'collisions': 0,
                    'collision_intersection': 0, 'collision_iou': 0}
     num_boxes = sample['num_boxes'].numpy()
+    labeled_boxes_init = tf.gather(
+      sample['groundtruth_boxes'], axis=1, indices=[1, 0, 3, 2]) * 256.0
 
     for _, metric in self.metrics.items():
       if isinstance(metric, ShapeAccuracyMetric):
@@ -598,8 +600,7 @@ class Evaluator:
         scene_id = str(sample['scene_filename'].numpy(), 'utf-8')
 
         # Get ground truth boxes
-        labeled_boxes = tf.gather(
-            sample['groundtruth_boxes'], axis=1, indices=[1, 0, 3, 2]) * 256.0
+        labeled_boxes = labeled_boxes_init
         if metric.threed:
           rotations_y = tf.concat([tf_utils.euler_from_rotation_matrix(
               tf.reshape(detections['rotations_3d'][i], [3, 3]),


### PR DESCRIPTION
#642 
Thank for your reply! I am sorry for that [`tf.reduce_mean in line 160 and 162`](https://github.com/tensorflow/graphics/blob/3c0b664d04af574225c5aeaea41478a43493aaff/tensorflow_graphics/rendering/tests/splat_test.py#L160) may not cause performance issue. But [`tf.gather`](https://github.com/tensorflow/graphics/blob/3c0b664d04af574225c5aeaea41478a43493aaff/tensorflow_graphics/projects/points_to_3Dobjects/utils/evaluator.py#L601) will be executed redundantly. 
Please check the PR and merge if you think it is reasonable.
Looking forward to your agreement.