### PR TITLE
fix: move openexr to runtime dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -U -r requirements.txt
+        pip install -U openexr
         pip install -U pytest coveralls
         pip install -U flake8
         pip install -U setuptools wheel

--- a/.github/workflows/tfg-main-pypi.yml
+++ b/.github/workflows/tfg-main-pypi.yml
@@ -21,6 +21,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -U -r requirements.txt
+        pip install -U openexr
         pip install -U pytest
         pip install -U setuptools wheel
         pip install -U twine

--- a/.github/workflows/tfg-nightly-pypi.yml
+++ b/.github/workflows/tfg-nightly-pypi.yml
@@ -25,6 +25,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -U -r requirements.txt
+        pip install -U openexr
         pip install -U pytest
         pip install -U setuptools wheel
         pip install -U twine

--- a/.github/workflows/tfg-test-pypi.yml
+++ b/.github/workflows/tfg-test-pypi.yml
@@ -21,6 +21,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -U -r requirements.txt
+        pip install -U openexr
         pip install -U pytest
         pip install -U setuptools wheel
         pip install -U twine

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ numpy >= 1.15.4
 psutil >= 5.7.0
 scipy >= 1.1.0
 tqdm >= 4.45.0
-OpenEXR >= 1.3.2
 termcolor >= 1.1.0
 trimesh >= 2.37.22
 # Required by trimesh.

--- a/tensorflow_graphics/__init__.py
+++ b/tensorflow_graphics/__init__.py
@@ -49,4 +49,4 @@ if _import_tfg_docs():
   __all__.remove("util")
 # pylint: enable=g-statement-before-imports,g-import-not-at-top
 
-__version__ = "HEAD"
+__version__ = "2022.6.9"

--- a/tensorflow_graphics/io/exr.py
+++ b/tensorflow_graphics/io/exr.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Utility functions for reading and writing EXR image files as numpy arrays."""
 
+
 # pylint: disable=c-extension-no-member
 
 from __future__ import absolute_import
@@ -21,7 +22,18 @@ from __future__ import print_function
 
 import Imath
 import numpy as np
-import OpenEXR
+from packaging import version
+
+try:
+  import OpenEXR
+except ImportError:
+  raise ImportError('OpenEXR is required for reading and writing EXR files, please install it.')
+else:
+  _min_version_openexr = "1.3.2"
+  if not version.parse(OpenEXR.__version__.decode("utf-8")) > version.parse(_min_version_openexr):
+    raise ImportError(
+        f"OpenEXR version {_min_version_openexr} is required, please upgrade it."
+    )
 from six.moves import range
 from six.moves import zip
 


### PR DESCRIPTION
OpenEXR is meant to be an optional dependency as raised in https://github.com/tensorflow/graphics/issues/421.

Moved it away from the requirements.txt (where it probably never should have been) and added a runtime check for the import and version.

Alternatively, having extras like [dev] or [openexr] in the requirements could be a step forward, in general, to make this better manageable.