### PR TITLE
Update levenberg_marquardt.py

### DIFF
--- a/tensorflow_graphics/math/optimizer/levenberg_marquardt.py
+++ b/tensorflow_graphics/math/optimizer/levenberg_marquardt.py
@@ -78,7 +78,7 @@ def _values_and_jacobian(residuals, variables):
   values = tf.expand_dims(values, axis=-1)
   return values, jacobian
 
-
+@tf.function
 def minimize(residuals,
              variables,
              max_iterations,


### PR DESCRIPTION
Retracing can be avoided by simply adding the tf.function decorator

sample showing the effect of the change on runtime and warning that is mentioned without decorator:
https://gist.github.com/Vesalon/a643c355d3caa2bf30f6ecf485505276