### PR TITLE
ci: declare workflow-level `contents: read` on 3 workflows

### DIFF
--- a/.github/workflows/tfg-main-pypi.yml
+++ b/.github/workflows/tfg-main-pypi.yml
@@ -3,6 +3,9 @@ name: Deploy tensorflow_graphics to pypi
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     if: github.repository == 'tensorflow/graphics'  # prevents action from running on forks

--- a/.github/workflows/tfg-nightly-pypi.yml
+++ b/.github/workflows/tfg-nightly-pypi.yml
@@ -7,6 +7,9 @@ on:
     # runs daily at 00:30 am
     - cron:  '30 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     if: github.repository == 'tensorflow/graphics'  # prevents action from running on forks

--- a/.github/workflows/tfg-test-pypi.yml
+++ b/.github/workflows/tfg-test-pypi.yml
@@ -3,6 +3,9 @@ name: Deploy to test-pypi
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     if: github.repository == 'tensorflow/graphics'  # prevents action from running on forks


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 3 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

The following files were left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Those scopes are best declared by maintainers: `build.yml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.